### PR TITLE
use default discord converter for CategoryChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Be sure to have Python 3.8 or higher installed as it is required by discord.py.
 Clone the projet and install the requirements (in a
 [venv](https://docs.python.org/library/venv.html) preferably):
 
-```
+```bash
 git clone https://github.com/ungdev/EtuUTT-Discord-Bot.git
 cd EtuUTT-Discord-Bot
 pip install -r requirements.txt
@@ -28,7 +28,7 @@ You also have to enable all the Privileged Gateway Intents as I assume they're e
 ---
 After having done all this you can launch the bot:
 
-```
+```bash
 python -m etuutt_bot
 ```
 

--- a/etuutt_bot/commands/role.py
+++ b/etuutt_bot/commands/role.py
@@ -88,7 +88,11 @@ class Role(app_commands.Group):
     @app_commands.describe(category="La catégorie dans laquelle créer les salons")
     async def add_ues(self, interaction: Interaction[EtuUTTBot], category: CategoryChannel):
         await interaction.response.defer(thinking=True)
-        roles = (await parse_roles("roles.txt")).get(category.name)
+        if category.name.startswith("Master"):
+            cat = category.name.split(" ")[1]
+        else:
+            cat = category.name.split(" ")[0]
+        roles = (await parse_roles("roles.txt")).get(cat)
         if roles is None:
             await interaction.followup.send("Cette catégorie ne comporte aucune UE.")
             return


### PR DESCRIPTION
En déclarant la catégorie comme étant du type `CategoryChannel`, discord fait automatiquement l'autocomplétion et empêche de rentrer un nom de catégorie inexistant (là où l'autocomplétion n'empêche pas de rentrer un choix qui n'est pas proposé).

Il y a déjà des vérifications qui sont faites dans la commande, ce qui fait que l'utilisateur ne peut pas rentrer une catégorie qui n'est pas destinée à contenir des salons d'UE.