### PR TITLE
Changement de la commande `getzeroone` en `lessthan`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Be sure to have Python 3.8 or higher installed as it is required by discord.py.
 Clone the projet and install the requirements (in a
 [venv](https://docs.python.org/library/venv.html) preferably):
 
-```
+```bash
 git clone https://github.com/ungdev/EtuUTT-Discord-Bot.git
 cd EtuUTT-Discord-Bot
 pip install -r requirements.txt
@@ -28,7 +28,7 @@ You also have to enable all the Privileged Gateway Intents as I assume they're e
 ---
 After having done all this you can launch the bot:
 
-```
+```bash
 python -m etuutt_bot
 ```
 

--- a/etuutt_bot/commands/role.py
+++ b/etuutt_bot/commands/role.py
@@ -10,8 +10,6 @@ from etuutt_bot.utils.message import split_msg
 from etuutt_bot.utils.role import parse_roles
 
 if TYPE_CHECKING:
-    from discord import Interaction
-
     from etuutt_bot.bot import EtuUTTBot
 
 
@@ -27,9 +25,9 @@ class Role(app_commands.Group):
 
     @app_commands.command(
         name="lessthan",
-        description="Affiche les rôles ayant moins de N personnes dedans (par défaut, n=2).",
+        description="Affiche les rôles ayant moins de n personnes dedans (par défaut, n=2).",
     )
-    async def get_less_than(self, interaction: discord.Interaction[EtuUTTBot], n: int = 2):
+    async def get_less_than(self, interaction: Interaction[EtuUTTBot], n: int = 2):
         await interaction.response.defer(thinking=True)
         roles = [r for r in interaction.guild.roles if len(r.members) < n]
         if len(roles) == 0:
@@ -54,11 +52,11 @@ class Role(app_commands.Group):
             msg += f"\n## Rôles avec {nb_members} membres :\n"
             msg += "\n".join(f"- {r.name}" for r in roles_group)
         chunks = list(split_msg(msg))
-        for chunk in chunks[:-1]:
+        for chunk in chunks[1:]:
             await interaction.channel.send(chunk)
         # send the last part of the message as a followup
         # to remove the "thinking" message
-        await interaction.followup.send(chunks[-1])
+        await interaction.followup.send(chunks[0])
 
     # Remove all users from a role
     @app_commands.checks.has_permissions(administrator=True)

--- a/etuutt_bot/utils/message.py
+++ b/etuutt_bot/utils/message.py
@@ -1,0 +1,25 @@
+def split_msg(msg: str):
+    """Si le message est trop long, divise le message en bouts plus petits.
+
+    Les bouts des messages renvoyés sont d'une longueur inférieure à 2000 caractères.
+    La séparation se fait au premier saut à la ligne situé avant le 2000ème caractère.
+    Si aucun saut de ligne n'est trouvé, la séparation se fait au premier espace trouvé.
+
+    Examples:
+        ```python
+        # le message contient trois lignes.
+        # Chaque ligne contient 1800 fois le caractère "a", "b" ou "c"
+        message = "\n".join(c * 1800 for c in "abc")
+        chunks = split_msg(message)
+        assert next(chunks) == "a" * 1800
+        assert next(chunks) == "b" * 1800
+        assert next(chunks) == "c" * 1800
+        ```
+    """
+    while len(msg) > 2000:
+        terminator = "\n" if "\n" in msg[:2000] else " "
+        split_index = msg.rfind(terminator, 0, 2000)
+        yield msg[:split_index]
+        # split at index+1 in order not to include the terminator
+        msg = msg[split_index + 1 :]
+    yield msg


### PR DESCRIPTION
La nouvelle commande est un peu plus flexible, puisqu'elle permet de choisir la borne supérieure du nombre de membres dans le rôle.

Pour la réécriture de la commande, j'ai également rajouté une nouvelle fonction utilitaire, `split_msg`, qui sépare automatiquement un texte en un itérateur de bouts d'une longueur inférieure à 2000 caractères. L'heuristique pour la séparation du texte consiste à rechercher le caractère de fin de ligne le plus proche du 2000ème caractère, à séparer le texte à cet endroit et à recommencer l'opération sur le bout qui se trouve après le point de séparation. Si un bout texte n'a pas de saut de ligne à l'intérieur, on sépare en utilisant les espaces.

Le format d'affichage de la réponse est également un peu amélioré. Les rôles sont groupés par nombre d'utilisateurs : 
![image](https://github.com/ungdev/EtuUTT-Discord-Bot/assets/56346771/99a89c59-3a57-48e7-bdf8-250543970b27)
