### PR TITLE
Role commands

### DIFF
--- a/etuutt_bot/commands/role.py
+++ b/etuutt_bot/commands/role.py
@@ -104,8 +104,9 @@ class RoleCog(commands.GroupCog, name="role"):
             return
         message = f"{len(duplicates)} rôles dupliqués :\n"
         for duplicate in duplicates:
-            message += f"- {duplicate[0].name}. Nombre de membres avec ce rôle : "
+            message += f"- **{duplicate[0].name}**. Nombre de membres avec ce rôle : "
             message += ", ".join(str(len(role.members)) for role in duplicate)
+            message += "\n"
         await interaction.followup.send(message)
 
     @app_commands.command(name="merge")

--- a/etuutt_bot/commands/role.py
+++ b/etuutt_bot/commands/role.py
@@ -33,7 +33,7 @@ class RoleCog(commands.GroupCog, name="role"):
         Args:
             interaction
             nb_min: Le nombre de personnes minimum ayant le rôle (par défaut : 0)
-            nb_max: Le nombre de personnes maximum ayant le rôle (par défaut : 9999)
+            nb_max: Le nombre de personnes maximum ayant le rôle (par défaut : 1)
         """
         await interaction.response.defer(thinking=True)
         if nb_min > nb_max:
@@ -87,7 +87,7 @@ class RoleCog(commands.GroupCog, name="role"):
 
     @app_commands.command(name="get_duplicates")
     async def get_duplicates(
-        self, interaction: Interaction[EtuUTTBot], case_sensitive: bool = True
+        self, interaction: Interaction[EtuUTTBot], case_sensitive: bool = False
     ):
         """Affiche tous les rôles qui sont dupliqués.
 
@@ -130,14 +130,16 @@ class RoleCog(commands.GroupCog, name="role"):
         """
         await interaction.response.defer(thinking=True)
         duplicates = self.role_service.get_duplicate(role, case_sensitive=case_sensitive)
-        if len(duplicates) < 2:
+        nb_duplicates = len(duplicates)
+        if nb_duplicates < 2:
             await interaction.followup.send(
                 "Ce rôle n'est pas dupliqué :thinking:\n"
                 "Utilisez la commande `get_duplicates` pour voir quels rôles sont dupliqués"
             )
+            return
         await self.role_service.merge(duplicates, merge_perms_strategy=merge_strategy)
-        await interaction.response.send(
-            f"Commande finie. {len(duplicates)} rôles fusionnés. :thumbs_up:"
+        await interaction.followup.send(
+            f"Commande finie. {nb_duplicates} rôles fusionnés. :thumbs_up:"
         )
 
     # define sub command group to manage channels

--- a/etuutt_bot/commands/role.py
+++ b/etuutt_bot/commands/role.py
@@ -26,7 +26,7 @@ class RoleCog(commands.GroupCog, name="role"):
 
     @app_commands.command(name="between")
     async def get_roles_with_framed_number_of_members(
-        self, interaction: Interaction[EtuUTTBot], nb_min: int = 0, nb_max: int = 9999
+        self, interaction: Interaction[EtuUTTBot], nb_min: int = 0, nb_max: int = 1
     ):
         """Affiche les rôles ayant plus de nb_min et moins de nb_max personnes dedans.
 

--- a/etuutt_bot/commands/role.py
+++ b/etuutt_bot/commands/role.py
@@ -37,7 +37,7 @@ class RoleCog(commands.GroupCog, name="role"):
         """
         await interaction.response.defer(thinking=True)
         if nb_min > nb_max:
-            await interaction.followup.send("Erreur : nb_min doit être inférieur à nb_max")
+            await interaction.followup.send("Erreur : nb_min doit être inférieur ou égal à nb_max")
             return
         roles = [r for r in interaction.guild.roles if nb_min <= len(r.members) <= nb_max]
         if len(roles) == 0:

--- a/etuutt_bot/services/role.py
+++ b/etuutt_bot/services/role.py
@@ -39,7 +39,7 @@ class RoleService:
         """
 
         def sort_key(r):
-            return r.name if case_sensitive else r.name.lower()
+            return r.name if case_sensitive else r.name.upper()
 
         roles = sorted(self._bot.watched_guild.roles, key=sort_key)
 

--- a/etuutt_bot/services/role.py
+++ b/etuutt_bot/services/role.py
@@ -41,7 +41,7 @@ class RoleService:
         def sort_key(r):
             return r.name if case_sensitive else r.name.lower()
 
-        roles = iter(sorted(self._bot.watched_guild.roles, key=sort_key))
+        roles = sorted(self._bot.watched_guild.roles, key=sort_key)
 
         res = []
         for _, group in itertools.groupby(roles):

--- a/etuutt_bot/services/role.py
+++ b/etuutt_bot/services/role.py
@@ -44,10 +44,10 @@ class RoleService:
         roles = sorted(self._bot.watched_guild.roles, key=sort_key)
 
         res = []
-        for _, group in itertools.groupby(roles):
-            group = list(group)
-            if len(group) > 1:
-                res.append(group)
+        for _, group in itertools.groupby(roles, key=sort_key):
+            values = list(group)
+            if len(values) > 1:
+                res.append(values)
         return res
 
     def get_duplicate(self, role: Role, *, case_sensitive: bool = True) -> list[Role]:

--- a/etuutt_bot/services/role.py
+++ b/etuutt_bot/services/role.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import itertools
+import operator
+from enum import Enum
+from functools import reduce
+from typing import TYPE_CHECKING, assert_never
+
+from discord import Permissions, Role
+
+if TYPE_CHECKING:
+    from etuutt_bot.bot import EtuUTTBot
+
+
+class MergeStrategy(Enum):
+    """Stratégie pour la fusion de plusieurs objets."""
+
+    Intersection = 1
+    """On garde l'intersection. ex: `[a, b, c] & [b, c, d] => [b, c,]`."""
+    Union = 2
+    """On garde l'union. ex: `[a, b, c] | [b, c, d] => [a, b, c, d]`."""
+    Clear = 3
+    """On ne garde rien. ex: `[a, b, c] | [b, c, d] => []`"""
+
+
+class RoleService:
+    """Service de gestion des rôles du serveur."""
+
+    def __init__(self, bot: EtuUTTBot):
+        self._bot = bot
+
+    def get_duplicates(self, *, case_sensitive: bool = True) -> list[list[Role]]:
+        """Cherche et retourne tous les rôles qui sont dupliqués.
+
+        Returns:
+            La liste des listes de duplication.
+            Chaque élément de la liste est une liste dont tous les
+            éléments sont des rôles dupliqués.
+        """
+
+        def sort_key(r):
+            return r.name if case_sensitive else r.name.lower()
+
+        roles = iter(sorted(self._bot.watched_guild.roles, key=sort_key))
+
+        res = []
+        for _, group in itertools.groupby(roles):
+            group = list(group)
+            if len(group) > 1:
+                res.append(group)
+        return res
+
+    def get_duplicate(self, role: Role, *, case_sensitive: bool = True) -> list[Role]:
+        """Cherche et retourne tous les rôles qui ont le même nom que le rôle donné.
+
+        Returns:
+            La liste des rôles dupliqués.
+            Le rôle passé en paramètre est inclus dedans.
+        """
+        if case_sensitive:
+            return [r for r in self._bot.watched_guild.roles if r.name == role.name]
+        return [r for r in self._bot.watched_guild.roles if r.name.lower() == role.name.lower()]
+
+    @staticmethod
+    def combined_perms(roles: list[Role], *, merge_strategy: MergeStrategy) -> Permissions:
+        """Calcule et renvoie le jeu de permissions correspondant à la stratégie donnée.
+        Args:
+            roles: les rôles dont on veut combiner les permissions
+            merge_strategy: la stratégie de combinaison des permissions
+
+        Returns:
+            Le jeu de permission obtenu par la combinaison des permissions de tous les rôles
+        """
+        perms = [role.permissions for role in roles]
+        if merge_strategy == MergeStrategy.Intersection:
+            return reduce(operator.or_, perms)
+        if merge_strategy == MergeStrategy.Union:
+            return reduce(operator.and_, perms)
+        if merge_strategy == MergeStrategy.Clear:
+            return Permissions.none()
+        assert_never(merge_strategy)
+
+    async def merge(self, roles: list[Role], *, merge_perms_strategy: MergeStrategy):
+        to_keep = roles[0]
+        # membres à qui il faut donner le rôle qu'on garde
+        members = {
+            member for role in roles for member in role.members if to_keep not in member.roles
+        }
+        for member in members:
+            await member.add_roles(to_keep)
+        await to_keep.edit(
+            permissions=self.combined_perms(roles, merge_strategy=merge_perms_strategy)
+        )


### PR DESCRIPTION
- change la commande `/role lessthan` en `/role between` ; au lieu de chercher les rôles avec moins de n membres, on va chercher les rôles avec entre n et m membres.
- ajoute la commande `/role get_duplicates` qui retourne tous les rôles dont le nom est dupliqué
- ajoute la commande `/role merge` qui permet de fusionner les membres et les permissions de plusieurs permissions ayant le même nom
- Crée la classe `RoleService` pour accomplir la logique de ces commandes.


- [x] Compléter d'abord #20 