### PR TITLE
Fix docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,9 +3,10 @@ on:
     push:
         branches:
             - main
-        paths:
-            - docs/**
-            - requirements-docs.txt
+        paths-ignore:
+            - .pre-commit-config.yaml
+            - requirements.txt
+            - requirements-dev.txt
     workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,7 @@ jobs:
                     python -m venv .venv
                     source .venv/bin/activate
                     python -m pip install --upgrade pip
-                    python -m pip install -r requirements-dev.txt
+                    python -m pip install -r requirements-docs.txt
                     echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
                     echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
             -   run: mkdocs gh-deploy --force

--- a/docs/tutorials/doc.md
+++ b/docs/tutorials/doc.md
@@ -1,6 +1,7 @@
 ## Compiler la documentation localement
 
-Si le projet est installé suivant les étapes décrite dans la section [Installation](install.md),
+Si le projet est installé suivant les étapes décrites dans la section [Installation](install.md)
+et que vous avez choisi d'installer les dépendances de documentation,
 vous pouvez compiler la documentation localement en exécutant la commande suivante :
 
 ```bash
@@ -10,7 +11,7 @@ mkdocs build
 La documentation sera générée dans le dossier `site`.
 Vous pouvez l'explorer dans votre navigateur en ouvrant le fichier `index.html`.
 
-## Editer la documentation
+## Éditer la documentation
 
 La documentation est écrite en Markdown et est générée à l'aide de [MkDocs](https://www.mkdocs.org/).
 Lorsque vous voulez travailler sur la documentation, vous pouvez lancer

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -193,10 +193,14 @@ git checkout main
 ```
 
 Puis installez les dépendances (de préférence dans un
-[venv](https://docs.python.org/3/library/venv.html)) :
+[venv](https://docs.python.org/3/library/venv.html)).
+Vous pouvez choisir d'installer les dépendances
+pour compiler la documentation ou non.
 
 ```
 pip install -U -r requirements-dev.txt
+# ou
+pip install -U -r requirements-docs.txt
 ```
 
 ## Configuration du projet

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -88,6 +88,7 @@ markdown_extensions:
             alternate_style: true
     -   pymdownx.tasklist:
             clickable_checkbox: true
+    -   pymdownx.tilde:
     -   pymdownx.emoji:
             emoji_index: !!python/name:material.extensions.emoji.twemoji
             emoji_generator: !!python/name:material.extensions.emoji.to_svg

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
--r requirements-docs.txt
 pre-commit ~= 3.7
 ruff == 0.4.4

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,3 @@
+-r requirements-dev.txt
 mkdocs-material ~= 9.5.22
 mkdocstrings-python ~= 1.10.0


### PR DESCRIPTION
- passage à paths-ignore plus cohérent pour deploy_docs
- ajout du support de tilde dans les fichiers markdown pour barrer du texte ou mettre du texte en indice
- permettre d'installer les dépendances de dev sans celles de doc (et maj de la doc pour refléter ce changement)