### PR TITLE
Improve ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Ignore all files then exclude files we need in the Docker image
 *
-!etuutt_bot/
-!public/
-!templates/
-!requirements.txt
+!/etuutt_bot/**/*.py
+!/public/
+!/templates/
+!/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,19 @@
 .idea/
 .vscode/
 
-# Python's venv
+# Python venv
+.venv/
 venv/
 
-# Python's cache
+# Python and Ruff cache
 __pycache__/
+.ruff_cache/
 
 # Logs folder
 logs/
 
 # Compiled documentation
-site/
+/site/
 
 # Data files
 /data/*


### PR DESCRIPTION
- Spécification que les éléments gardés sont à la racine dans le dockerignore
- On ne prend que les fichiers Python dans le dossier etuutt_bot dans le dockerignore (pour éviter les dossiers `__pychache__` quand on crée l'image en local)
- Ajout de `.venv` dans le gitignore pour ceux qui préfèrent à just `venv`
- Ajout de Ruff cache même si il est censé contenir un gitignore avec *
- Le dossier `site` est censé être créé à la racine donc le précise